### PR TITLE
Fabo/check for version 1.5.3

### DIFF
--- a/pending/fabo_fix-to-high-version
+++ b/pending/fabo_fix-to-high-version
@@ -1,0 +1,1 @@
+[Fixed] Reduce requirement to app version 1.5.3 @faboweb

--- a/src/cosmos-ledger.ts
+++ b/src/cosmos-ledger.ts
@@ -7,7 +7,7 @@ import * as Ripemd160 from 'ripemd160'
 import * as bech32 from 'bech32'
 
 const INTERACTION_TIMEOUT = 120 // seconds to wait for user action on Ledger, currently is always limited to 60
-const REQUIRED_COSMOS_APP_VERSION = '1.5.5'
+const REQUIRED_COSMOS_APP_VERSION = '1.5.3'
 
 declare global {
   interface Window {


### PR DESCRIPTION
We were checking for app version 1.5.5 which doesn't exist. App version 1.5.3 is also valid.