### PR TITLE
Fabo/throw unknown error

### DIFF
--- a/pending/fabo_throw-unknown-error
+++ b/pending/fabo_throw-unknown-error
@@ -1,0 +1,1 @@
+[Fixed] Unknown errors were not bubbled up to the user @faboweb

--- a/src/cosmos-ledger.ts
+++ b/src/cosmos-ledger.ts
@@ -127,6 +127,9 @@ export default class Ledger {
             "You did not select a Ledger device. If you didn't see your Ledger, check if the Ledger is plugged in and unlocked."
           )
         }
+
+        // throw unknown error
+        throw err
       }
     }
 


### PR DESCRIPTION
unknown webusb errors were not thrown and therefor the transport was not defined later in the code