### PR TITLE
Fix build script declarationDir compiler option

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "prebuild": "rimraf lib",
-    "build": "npx tsc src/cosmos-ledger.ts --outDir lib --sourceMap --declaration",
+    "build": "npx tsc src/cosmos-ledger.ts --outDir lib --sourceMap --declaration --declarationDir lib/types",
     "test": "jest --coverage",
     "test:watch": "jest --coverage --watch",
     "test:prod": "npm run lint && npm run test -- --no-cache",


### PR DESCRIPTION
I believe specifying these flags in the `build` script overrides the `declarationDir` setting in `tsconfig.json`. In the currently released version the typings can't be found because they're in `lib/cosmos-ledger.d.ts`, not `lib/types/cosmos-ledger.d.ts` (as specified in the `typings` field of `package.json`).